### PR TITLE
changing testing to latest

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -91,7 +91,7 @@ setup_env() {
   fi
 
   INSTALL_ACORN_CHANNEL_URL=${INSTALL_ACORN_CHANNEL_URL:-'https://update.acrn.io/v1-release/channels'}
-  INSTALL_ACORN_CHANNEL=${INSTALL_ACORN_CHANNEL:-'testing'}
+  INSTALL_ACORN_CHANNEL=${INSTALL_ACORN_CHANNEL:-'latest'}
 }
 
 # --- check if skip download environment variable set ---


### PR DESCRIPTION
Right now with this script the output is 
```
[INFO]  Finding release for channel testing
[INFO]  Using v0.1.0 as release
[INFO]  Downloading hash https://github.com/acorn-io/acorn/releases/download/v0.1.0/checksums.txt
[INFO]  Downloading archive https://github.com/acorn-io/acorn/releases/download/v0.1.0/acorn-v0.1.0-macOS-universal.tar.gz

```
testing should be changed to latest as I saw there is a latest channel as well.