### PR TITLE
Make tar use default options

### DIFF
--- a/get.sh
+++ b/get.sh
@@ -292,6 +292,7 @@ expand_archive() {
   if [ "${EXT}" = ".zip" ]; then
     unzip ${TMP_ARCHIVE} -d ${TMP_DIR}
   else
+    unset TAR_OPTIONS # ensure tar operates with default settings
     tar xzf ${TMP_ARCHIVE} -C ${TMP_DIR}
   fi
 


### PR DESCRIPTION
This unsets TAR_OPTIONS to ensure tar operates with default settings. In my environment, I have `TAR_OPTIONS=--one-top-level`, which breaks extraction in get.sh:

```
[INFO]  Finding release for channel latest
[INFO]  Using v0.4.2 as release
[INFO]  Downloading hash https://github.com/acorn-io/acorn/releases/download/v0.4.2/checksums.txt
[INFO]  Downloading archive https://github.com/acorn-io/acorn/releases/download/v0.4.2/acorn-v0.4.2-linux-amd64.tar.gz
[INFO]  Verifying binary download
tar: acorn: Cannot open: File exists
tar: Exiting with failure status due to previous errors
```

Signed-off-by: Stephen Benjamin <stephen@bitbin.de>